### PR TITLE
feat: throw forbidden error when package is blocked by security policy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ sudo: false
 node_js:
   - "7"
   - "6"
-  - "4"

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ function pickManifest (packument, wanted, opts) {
   })
   const policyRestrictions = packument.policyRestrictions
   const restrictedVersions = policyRestrictions
-  ? Object.keys(packument.policyRestrictions.restrictedVersions) : []
+  ? Object.keys(policyRestrictions.versions) : []
 
   function enjoyableBy (v) {
     return !time || (
@@ -102,7 +102,7 @@ function pickManifest (packument, wanted, opts) {
   )
   if (!manifest) {
     // Check if target is forbidden
-    const isForbidden = target && policyRestrictions && packument.policyRestrictions.restrictedVersions[target]
+    const isForbidden = target && policyRestrictions && policyRestrictions.versions[target]
     const pckg = `${packument.name}@${wanted}${
       opts.enjoyBy
         ? ` with an Enjoy By date of ${
@@ -112,7 +112,7 @@ function pickManifest (packument, wanted, opts) {
     }`
 
     if (isForbidden) {
-      err = new Error(`Could not download ${pckg} due to policy violations.\n${packument.policyRestrictions.message}\n`)
+      err = new Error(`Could not download ${pckg} due to policy violations.\n${policyRestrictions.message}\n`)
       err.code = 'E403'
     } else {
       err = new Error(`No matching version found for ${pckg}.`)

--- a/test/index.js
+++ b/test/index.js
@@ -131,7 +131,7 @@ test('ETARGET if range does not match anything', t => {
 test('E403 if version is forbidden', t => {
   const metadata = {
     policyRestrictions: {
-      restrictedVersions: {
+      versions: {
         '2.1.0': { version: '2.1.0' }
       }
     },
@@ -216,7 +216,7 @@ test('errors if metadata has no versions', t => {
 
 test('errors if metadata has no versions or restricted versions', t => {
   t.throws(() => {
-    pickManifest({versions: {}, policyRestrictions: { restrictedVersions: {} }}, '^1.0.0')
+    pickManifest({versions: {}, policyRestrictions: { versions: {} }}, '^1.0.0')
   }, {code: 'ENOVERSIONS'})
   t.throws(() => {
     pickManifest({}, '^1.0.0')

--- a/test/index.js
+++ b/test/index.js
@@ -128,6 +128,25 @@ test('ETARGET if range does not match anything', t => {
   t.done()
 })
 
+test('E403 if version is forbidden', t => {
+  const metadata = {
+    policyRestrictions: {
+      restrictedVersions: {
+        '2.1.0': { version: '2.1.0' }
+      }
+    },
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '2.0.0': { version: '2.0.0' },
+      '2.0.5': { version: '2.0.5' }
+    }
+  }
+  t.throws(() => {
+    pickManifest(metadata, '2.1.0')
+  }, {code: 'E403'}, 'got correct error on match failure')
+  t.done()
+})
+
 test('if `defaultTag` matches a given range, use it', t => {
   const metadata = {
     'dist-tags': {
@@ -188,6 +207,16 @@ test('* ranges use `defaultTag` if no versions match', t => {
 test('errors if metadata has no versions', t => {
   t.throws(() => {
     pickManifest({versions: {}}, '^1.0.0')
+  }, {code: 'ENOVERSIONS'})
+  t.throws(() => {
+    pickManifest({}, '^1.0.0')
+  }, {code: 'ENOVERSIONS'})
+  t.done()
+})
+
+test('errors if metadata has no versions or restricted versions', t => {
+  t.throws(() => {
+    pickManifest({versions: {}, policyRestrictions: { restrictedVersions: {} }}, '^1.0.0')
   }, {code: 'ENOVERSIONS'})
   t.throws(() => {
     pickManifest({}, '^1.0.0')


### PR DESCRIPTION
## :pencil2: Changes
This PR introduces a new error in the case that a forbidden package was requested and blocked by the security proxy. If no manifest was found under the `versions` object, then a check is done to verify if the package is forbidden under the `restrictedVersions` object. If it is, a new error code is thrown `E403` and the admin custom message will be shown on the CLI like:
```
➜  security-messaging npm i ecstatic@1.0.0
npm ERR! code E403
npm ERR! 403 Could not download ecstatic@1.0.0 due to policy violations.
npm ERR! 403 Use `npm audit fix` to upgrade this dependency.
npm ERR! 403
npm ERR! 403 In most cases you or one of your dependencies are requesting
npm ERR! 403 a package version that is forbidden by your security policy
npm ERR! 403 please contact your npme admin.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/claudiahdz/.npm/_logs/2019-08-09T20_46_04_225Z-debug.log
``` 

If no policy restrictions are found on the packument then the behavior will continue as is right now and throw a `ETARGET` error.

## :link: References
RFC: https://npmjs.slab.com/posts/proposed-package-filtering-messaging-on-the-cli-kejlhyow

## :mag: Testing
_Automated testing_
- Checks if E403 when version is forbidden
- Checks if errors when metadata has no versions or restricted versions

✅ This change has unit test coverage

## ⚠️  Warning (Blockers)
This PR depends on: https://github.com/npm/cli/pull/234