### PR TITLE
fix: throw 403 for forbidden major/minor versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,6 +96,10 @@ function pickManifest (packument, wanted, opts) {
     target = stillFresh[0]
   }
 
+  if (!target && restrictedVersions) {
+    target = semver.maxSatisfying(restrictedVersions, wanted, true)
+  }
+
   const manifest = (
     target &&
     packument.versions[target]

--- a/test/index.js
+++ b/test/index.js
@@ -147,6 +147,46 @@ test('E403 if version is forbidden', t => {
   t.done()
 })
 
+test('E403 if version is forbidden, provided a minor version', t => {
+  const metadata = {
+    policyRestrictions: {
+      versions: {
+        '2.1.0': { version: '2.1.0' },
+        '2.1.5': { version: '2.1.5' }
+      }
+    },
+    versions: {
+      '1.0.0': { version: '1.0.0' },
+      '2.0.0': { version: '2.0.0' },
+      '2.0.5': { version: '2.0.5' }
+    }
+  }
+  t.throws(() => {
+    pickManifest(metadata, '2.1')
+  }, {code: 'E403'}, 'got correct error on match failure')
+  t.done()
+})
+
+test('E403 if version is forbidden, provided a major version', t => {
+  const metadata = {
+    policyRestrictions: {
+      versions: {
+        '1.0.0': { version: '1.0.0' },
+        '2.1.0': { version: '2.1.0' },
+        '2.1.5': { version: '2.1.5' }
+      }
+    },
+    versions: {
+      '2.0.0': { version: '2.0.0' },
+      '2.0.5': { version: '2.0.5' }
+    }
+  }
+  t.throws(() => {
+    pickManifest(metadata, '1')
+  }, {code: 'E403'}, 'got correct error on match failure')
+  t.done()
+})
+
 test('if `defaultTag` matches a given range, use it', t => {
   const metadata = {
     'dist-tags': {


### PR DESCRIPTION
## :pencil2: Changes
This PR fixes a bug where `target` was not being resolved correctly for major/minor versions. Since elements are removed from the `versions` object of the packument by the proxy the algorithm had trouble finding a satisfying version to resolve the target to. This led to a `null` target which was interpreted as a not found.  Adding an extra check on the `policyRestrictions.versions` object allows us to correctly resolve the target and later check if it's a forbidden target or not.

Ex. `npm install lodash@1`
 
## :link: References
Card: https://npmjsinc.leankit.com/card/891629888

## :mag: Testing
_Automated testing_
- Checks if E403 if version when forbidden, provided a minor version
- Checks if E403 if version when forbidden, provided a major version
✅ This change has unit test coverage