### PR TITLE
Prefer satisfying engines req, refactor heuristic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,94 @@
+---
+################################################################################
+# Template - Node CI
+#
+# Description:
+#   This contains the basic information to: install dependencies, run tests,
+#   get coverage, and run linting on a nodejs project. This template will run
+#   over the MxN matrix of all operating systems, and all current LTS versions
+#   of NodeJS.
+#
+# Dependencies:
+#   This template assumes that your project is using the `tap` module for
+#   testing. If you're not using this module, then the step that runs your
+#   coverage will need to be adjusted.
+#
+################################################################################
+name: Node CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [10.x, 12.x, 13.x]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Checkout the repository
+      - uses: actions/checkout@v2
+        # Installs the specific version of Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      ################################################################################
+      # Install Dependencies
+      #
+      #   ASSUMPTIONS:
+      #     - The project has a package-lock.json file
+      #
+      #   Simply run the tests for the project.
+      ################################################################################
+      - name: Install dependencies
+        run: npm ci
+
+      ################################################################################
+      # Run Testing
+      #
+      #   ASSUMPTIONS:
+      #     - The project has `tap` as a devDependency
+      #     - There is a script called "test" in the package.json
+      #
+      #   Simply run the tests for the project.
+      ################################################################################
+      - name: Run tests
+        run: npm test
+
+      ################################################################################
+      # Run coverage check
+      #
+      #   ASSUMPTIONS:
+      #     - The project has `tap` as a devDependency
+      #     - There is a script called "coverage" in the package.json
+      #
+      #   Coverage should only be posted once, we are choosing the latest LTS of
+      #   node, and ubuntu as the matrix point to post coverage from. We limit
+      #   to the 'push' event so that coverage ins't posted twice from the
+      #   pull-request event, and push event (line 3).
+      ################################################################################
+      - name: Run coverage report
+        if: github.event_name == 'push' && matrix.node-version == '12.x' && matrix.os == 'ubuntu-latest'
+        run: npm run coverage
+        env:
+          # The environment variable name is leveraged by `tap`
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+
+      ################################################################################
+      # Run linting
+      #
+      #   ASSUMPTIONS:
+      #     - There is a script called "lint" in the package.json
+      #
+      #   We run linting AFTER we run testing and coverage checks, because if a step
+      #   fails in an GitHub Action, all other steps are not run. We don't want to
+      #   fail to run tests or coverage because of linting. It should be the lowest
+      #   priority of all the steps.
+      ################################################################################
+      - name: Run linter
+        run: npm run lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - node
-  - 12
-  - 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [6.0.0](https://github.com/npm/npm-pick-manifest/compare/v5.0.0...v6.0.0) (2020-02-18)
+
+
+### ⚠ BREAKING CHANGES
+
+* 'enjoyBy' is no longer an acceptable alias.
+
+### Features
+
+* add GitHub Actions file for ci ([8985247](https://github.com/npm/npm-pick-manifest/commit/898524727fa157f46fdf4eb0c11148ae4808226b))
+
+
+### Bug Fixes
+
+* Handle edge cases around before:Date and filtering staged publishes ([ed2f92e](https://github.com/npm/npm-pick-manifest/commit/ed2f92e7fdc9cc7836b13ebc73e17d8fd296a07e))
+* remove figgy pudding ([c24fed2](https://github.com/npm/npm-pick-manifest/commit/c24fed25b8f77fbbcc3107030f2dfed55fa54222))
+* remove outdated cruft from docs ([aae7ef7](https://github.com/npm/npm-pick-manifest/commit/aae7ef7625ddddbac0548287e5d57b8f76593322))
+* update some missing {loose:true} semver configs ([4015424](https://github.com/npm/npm-pick-manifest/commit/40154244a3fe1af86462bc1d6165199fc3315c10))
+* Use canonical 'before' config name ([029de59](https://github.com/npm/npm-pick-manifest/commit/029de59bda6d3376f03760a00efe4ac9d997c623))
+
 ## [5.0.0](https://github.com/npm/npm-pick-manifest/compare/v4.0.0...v5.0.0) (2019-12-15)
 
 

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ const engineOk = (manifest, npmVersion, nodeVersion) => {
 }
 
 const isBefore = (verTimes, ver, time) =>
-  !verTimes || Date.parse(verTimes[ver]) <= time
+  !verTimes || !verTimes[ver] || Date.parse(verTimes[ver]) <= time
 
 const pickManifest = (packument, wanted, opts) => {
   const {
@@ -32,7 +32,7 @@ const pickManifest = (packument, wanted, opts) => {
   const restricted = (packument.policyRestrictions &&
     packument.policyRestrictions.versions) || {}
 
-  const time = before && verTimes ? Date.parse(before) : Infinity
+  const time = before && verTimes ? +(new Date(before)) : Infinity
   const spec = npa.resolve(name, wanted || defaultTag)
   const type = spec.type
   const distTags = packument['dist-tags'] || {}

--- a/index.js
+++ b/index.js
@@ -2,133 +2,154 @@
 
 const npa = require('npm-package-arg')
 const semver = require('semver')
+const { checkEngine } = require('npm-install-checks')
 
-module.exports = pickManifest
-function pickManifest (packument, wanted, opts = {}) {
+const engineOk = (manifest, npmVersion, nodeVersion) => {
+  try {
+    checkEngine(manifest, npmVersion, nodeVersion)
+    return true
+  } catch (_) {
+    return false
+  }
+}
+
+const isBefore = (verTimes, ver, time) =>
+  !verTimes || Date.parse(verTimes[ver]) <= time
+
+const pickManifest = (packument, wanted, opts) => {
   const {
     defaultTag = 'latest',
     before = null,
-    includeDeprecated = false
+    nodeVersion = process.version,
+    npmVersion = null,
+    includeStaged = false
   } = opts
 
-  const time = before && packument.time && +(new Date(before))
-  const spec = npa.resolve(packument.name, wanted)
+  const { name, time: verTimes } = packument
+  const versions = packument.versions || {}
+  const staged = (includeStaged && packument.stagedVersions &&
+    packument.stagedVersions.versions) || {}
+  const restricted = (packument.policyRestrictions &&
+    packument.policyRestrictions.versions) || {}
+
+  const time = before && verTimes ? Date.parse(before) : Infinity
+  const spec = npa.resolve(name, wanted || defaultTag)
   const type = spec.type
-  if (type === 'version' || type === 'range') {
-    wanted = semver.clean(wanted, true) || wanted
-  }
   const distTags = packument['dist-tags'] || {}
-  const versions = Object.keys(packument.versions || {}).filter(v => {
-    return semver.valid(v, true)
-  })
-  const policyRestrictions = packument.policyRestrictions
-  const restrictedVersions = policyRestrictions
-    ? Object.keys(policyRestrictions.versions) : []
 
-  function enjoyableBy (v) {
-    return !time || (
-      packument.time[v] && time >= +(new Date(packument.time[v]))
-    )
-  }
-
-  let err
-
-  if (!versions.length && !restrictedVersions.length) {
-    err = new Error(`No valid versions available for ${packument.name}`)
-    err.code = 'ENOVERSIONS'
-    err.name = packument.name
-    err.type = type
-    err.wanted = wanted
-    throw err
-  }
-
-  let target
-
-  if (type === 'tag' && enjoyableBy(distTags[wanted])) {
-    target = distTags[wanted]
-  } else if (type === 'version') {
-    target = wanted
-  } else if (type !== 'range' && enjoyableBy(distTags[wanted])) {
+  if (type !== 'tag' && type !== 'version' && type !== 'range') {
     throw new Error('Only tag, version, and range are supported')
   }
 
-  const tagVersion = distTags[defaultTag]
-
-  if (
-    !target &&
-    tagVersion &&
-    packument.versions[tagVersion] &&
-    enjoyableBy(tagVersion) &&
-    semver.satisfies(tagVersion, wanted, true)
-  ) {
-    target = tagVersion
-  }
-
-  if (!target && !includeDeprecated) {
-    const undeprecated = versions.filter(v => !packument.versions[v].deprecated && enjoyableBy(v)
-    )
-    target = semver.maxSatisfying(undeprecated, wanted, true)
-  }
-  if (!target) {
-    const stillFresh = versions.filter(enjoyableBy)
-    target = semver.maxSatisfying(stillFresh, wanted, true)
-  }
-
-  if (!target && wanted === '*' && enjoyableBy(tagVersion)) {
-    // This specific corner is meant for the case where
-    // someone is using `*` as a selector, but all versions
-    // are pre-releases, which don't match ranges at all.
-    target = tagVersion
-  }
-
-  if (
-    !target &&
-    time &&
-    type === 'tag' &&
-    distTags[wanted] &&
-    !enjoyableBy(distTags[wanted])
-  ) {
-    const stillFresh = versions.filter(v =>
-      enjoyableBy(v) && semver.lte(v, distTags[wanted], true)
-    ).sort(semver.rcompare)
-    target = stillFresh[0]
-  }
-
-  if (!target && restrictedVersions) {
-    target = semver.maxSatisfying(restrictedVersions, wanted, true)
-  }
-
-  const manifest = (
-    target &&
-    packument.versions[target]
-  )
-  if (!manifest) {
-    // Check if target is forbidden
-    const isForbidden = target && policyRestrictions && policyRestrictions.versions[target]
-    const pckg = `${packument.name}@${wanted}${
-      before
-        ? ` with an Enjoy By date of ${
-          new Date(before).toLocaleString()
-        }. Maybe try a different date?`
-        : ''
-    }`
-
-    if (isForbidden) {
-      err = new Error(`Could not download ${pckg} due to policy violations.\n${policyRestrictions.message}\n`)
-      err.code = 'E403'
+  // if the type is 'tag', and not just the implicit default, then it must
+  // be that exactly, or nothing else will do.
+  if (wanted && type === 'tag') {
+    const ver = distTags[wanted]
+    // if the version in the dist-tags is before the before date, then
+    // we use that.  Otherwise, we get the highest precedence version
+    // prior to the dist-tag.
+    if (isBefore(verTimes, ver, time)) {
+      return versions[ver] || staged[ver] || restricted[ver]
     } else {
-      err = new Error(`No matching version found for ${pckg}.`)
-      err.code = 'ETARGET'
+      return pickManifest(packument, `<=${ver}`, opts)
     }
-
-    err.name = packument.name
-    err.type = type
-    err.wanted = wanted
-    err.versions = versions
-    err.distTags = distTags
-    err.defaultTag = defaultTag
-    throw err
-  } else {
-    return manifest
   }
+
+  // similarly, if a specific version, then only that version will do
+  if (wanted && type === 'version') {
+    const ver = semver.clean(wanted, { loose: true })
+    const mani = versions[ver] || staged[ver] || restricted[ver]
+    return isBefore(verTimes, ver, time) ? mani : null
+  }
+
+  // ok, sort based on our heuristics, and pick the best fit
+  const range = type === 'range' ? wanted : '*'
+
+  // if the range is *, then we prefer the 'latest' if available
+  const defaultVer = distTags[defaultTag]
+  if (defaultVer && (range === '*' || semver.satisfies(defaultVer, range))) {
+    const mani = versions[defaultVer]
+    if (mani && isBefore(verTimes, defaultVer, time)) {
+      return mani
+    }
+  }
+
+  // ok, actually have to sort the list and take the winner
+  const allEntries = Object.entries(versions)
+    .concat(Object.entries(staged))
+    .concat(Object.entries(restricted))
+    .filter(([ver, mani]) => isBefore(verTimes, ver, time))
+
+  if (!allEntries.length) {
+    throw Object.assign(new Error(`No valid versions available for ${name}`), {
+      code: 'ENOVERSIONS',
+      name,
+      type,
+      wanted,
+      versions: Object.keys(versions)
+    })
+  }
+
+  const entries = allEntries.filter(([ver, mani]) =>
+    semver.satisfies(ver, range, { loose: true }))
+    .sort((a, b) => {
+      const [vera, mania] = a
+      const [verb, manib] = b
+      const notrestra = !restricted[a]
+      const notrestrb = !restricted[b]
+      const notstagea = !staged[a]
+      const notstageb = !staged[b]
+      const notdepra = !mania.deprecated
+      const notdeprb = !manib.deprecated
+      const enginea = engineOk(mania, npmVersion, nodeVersion)
+      const engineb = engineOk(manib, npmVersion, nodeVersion)
+      // sort by:
+      // - not restricted
+      // - not staged
+      // - not deprecated and engine ok
+      // - engine ok
+      // - not deprecated
+      // - semver
+      return (notrestrb - notrestra) ||
+        (notstageb - notstagea) ||
+        ((notdeprb && engineb) - (notdepra && enginea)) ||
+        (engineb - enginea) ||
+        (notdeprb - notdepra) ||
+        semver.rcompare(vera, verb)
+    })
+
+  return entries[0] && entries[0][1]
+}
+
+module.exports = (packument, wanted, opts = {}) => {
+  const picked = pickManifest(packument, wanted, opts)
+  const policyRestrictions = packument.policyRestrictions
+  const restricted = (policyRestrictions && policyRestrictions.versions) || {}
+
+  if (picked && !restricted[picked.version]) {
+    return picked
+  }
+
+  const { before = null, defaultTag = 'latest' } = opts
+  const bstr = before ? new Date(before).toLocaleString() : ''
+  const { name } = packument
+  const pckg = `${name}@${wanted}` +
+    (before ? ` with a date before ${bstr}` : '')
+
+  const isForbidden = picked && !!restricted[picked.version]
+  const polMsg = isForbidden ? policyRestrictions.message : ''
+
+  const msg = !isForbidden ? `No matching version found for ${pckg}.`
+    : `Could not download ${pckg} due to policy violations:\n${polMsg}`
+
+  const code = isForbidden ? 'E403' : 'ETARGET'
+  throw Object.assign(new Error(msg), {
+    code,
+    type: npa.resolve(packument.name, wanted).type,
+    wanted,
+    versions: Object.keys(packument.versions),
+    name,
+    distTags: packument['dist-tags'],
+    defaultTag
+  })
 }

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ const pickManifest = (packument, wanted, opts) => {
 
   // if the range is *, then we prefer the 'latest' if available
   const defaultVer = distTags[defaultTag]
-  if (defaultVer && (range === '*' || semver.satisfies(defaultVer, range))) {
+  if (defaultVer && (range === '*' || semver.satisfies(defaultVer, range, { loose: true }))) {
     const mani = versions[defaultVer]
     if (mani && isBefore(verTimes, defaultVer, time)) {
       return mani
@@ -115,7 +115,7 @@ const pickManifest = (packument, wanted, opts) => {
         ((notdeprb && engineb) - (notdepra && enginea)) ||
         (engineb - enginea) ||
         (notdeprb - notdepra) ||
-        semver.rcompare(vera, verb)
+        semver.rcompare(vera, verb, { loose: true })
     })
 
   return entries[0] && entries[0][1]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-pick-manifest",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3414,6 +3414,21 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
+    "npm-install-checks": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/npm-install-checks/-/npm-install-checks-4.0.0.tgz",
+      "integrity": "sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==",
+      "requires": {
+        "semver": "^7.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+        }
+      }
+    },
     "npm-package-arg": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1683,11 +1683,6 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
-    "figgy-pudding": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
-      "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npm-pick-manifest",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "Resolves a matching manifest from a package metadata document according to standard npm semver resolution rules.",
   "main": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "license": "ISC",
   "dependencies": {
     "figgy-pudding": "^3.5.1",
+    "npm-install-checks": "^4.0.0",
     "npm-package-arg": "^8.0.0",
     "semver": "^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "*.js"
   ],
   "scripts": {
+    "coverage": "tap",
     "lint": "standard",
     "postrelease": "npm publish",
     "posttest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "*.js"
   ],
   "scripts": {
+    "lint": "standard",
     "postrelease": "npm publish",
-    "posttest": "standard",
+    "posttest": "npm run lint",
     "prepublishOnly": "git push --follow-tags",
     "prerelease": "npm t",
     "release": "standard-version -s",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "license": "ISC",
   "dependencies": {
-    "figgy-pudding": "^3.5.1",
     "npm-install-checks": "^4.0.0",
     "npm-package-arg": "^8.0.0",
     "semver": "^7.0.0"

--- a/test/index.js
+++ b/test/index.js
@@ -365,6 +365,7 @@ test('accepts opts.before option to do date-based cutoffs', t => {
       '1.0.0': '2018-01-01T00:00:00.000Z',
       '2.0.0': '2018-01-02T00:00:00.000Z',
       '2.0.1': '2018-01-03T00:00:00.000Z',
+      '2.0.2': '2018-01-03T00:00:00.123Z',
       '3.0.0': '2018-01-04T00:00:00.000Z'
     },
     versions: {
@@ -384,6 +385,16 @@ test('accepts opts.before option to do date-based cutoffs', t => {
     before: '2018-01-02'
   })
   t.equal(manifest.version, '2.0.0', 'tag specs pick highest before dist-tag but within the range in question')
+
+  manifest = pickManifest(metadata, '*', {
+    before: Date.parse('2018-01-03T00:00:00.000Z')
+  })
+  t.equal(manifest.version, '2.0.1', 'numeric timestamp supported with ms accuracy')
+
+  manifest = pickManifest(metadata, '*', {
+    before: new Date('2018-01-03T00:00:00.000Z')
+  })
+  t.equal(manifest.version, '2.0.1', 'date obj supported with ms accuracy')
 
   t.throws(() => pickManifest(metadata, '3.0.0', {
     before: '2018-01-02'
@@ -445,12 +456,19 @@ test('support selecting staged versions if allowed by options', t => {
       versions: {
         '2.0.0': { version: '2.0.0' }
       }
+    },
+    time: {
+      '1.0.0': '2018-01-03T00:00:00.000Z'
     }
   }
 
   t.equal(pickManifest(pack, '1||2').version, '1.0.0')
   t.equal(pickManifest(pack, '1||2', { includeStaged: true }).version, '1.0.0')
   t.equal(pickManifest(pack, '2', { includeStaged: true }).version, '2.0.0')
+  t.equal(pickManifest(pack, '2', {
+    includeStaged: true,
+    before: '2018-01-01'
+  }).version, '2.0.0', 'version without time entry not subject to before filtering')
   t.throws(() => pickManifest(pack, '2'), { code: 'ETARGET' })
   t.throws(() => pickManifest(pack, 'borked'), { code: 'ETARGET' })
 


### PR DESCRIPTION
This refactors a lot of the logic in this module, so that it's a
somewhat less haphazard collection of conditionals.

Logic now:

- Include policyRestrictions in the search if present.
- Include stagedVersions in the search if present, and includeStaged set
- If a dist-tag is specified, and it's not after the 'before' date, pull
  it from the versions, staged, or restricted.
- If a dist-tag is specified, and it IS after the 'before' date, then
  get the highest precedence version that is less than or equal to the
  dist-tagged version
- If a version is specified, return it from the
  versions/restricted/staged set if before the 'before' date.  If it's
  not old enough, raise ETARGET.  (This is a breaking change from v5,
  where specifying a definite version number would the override 'before'
  setting.)
- If the default dist-tag satisfies the range (or if the range is `'*'`
  or `''`) then return the default dist-tag version if it's older than
  the 'before' setting.

At this point, we know it's a range, and have to apply heuristics to
find the best fit.  Sort all the available versions by:

- Whether or not it's in the policyRestrictions versions.  (All
  non-restricted versions come before all restricted versions.)
- Whether or not it's a staged version.  (Properly published versions
  take precedence over staged versions.)
- All versions that are not deprecated, and where the declared engine
  requirements are met.  (OS/CPU are *not* checked, since they are
  much more unlikely to change over time in a given module, and will
  crash the install anyway.)
- All versions where the engine requirements are met (but which may be
  deprecated).
- Deprecated versions
- Beyond that (within a given set of all the above heuristics), sort by
  SemVer precedence.

Then we just take the first thing on the list.

If there are no versions (or none created before the `before` option),
then `ENOVERSIONS` is raised.

If the version selected is in the policyRestrictions set, then `E403` is
raised.

If there are versions, but none of them satisfy the given requirements,
then `ETARGET` is raised.

BREAKING CHANGES:

- Deprecated versions MAY be returned if there are no other options, but
  will always be avoided if possible.  (Along with this, the
  `includeDeprecated` flag no longer is relevant.)
- Unsatisfied stated engines requirements are avoided if possible.
- Remove the hole in `before` filtering, where declaring a specific
  version would work, even if it was published _after_ the date.

FEATURE CHANGES:

- Add support for stagedVersions
- Add the `includeStaged` flag
