### PR TITLE
feat: improve heuristics when dist-tags.latest is in range

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -123,9 +123,15 @@ const pickManifest = (packument, wanted, opts) => {
   const defaultVer = distTags[defaultTag]
   if (defaultVer &&
       (range === '*' || semver.satisfies(defaultVer, range, { loose: true })) &&
+      !restricted[defaultVer] &&
       !shouldAvoid(defaultVer, avoid)) {
     const mani = versions[defaultVer]
-    if (mani && isBefore(verTimes, defaultVer, time)) {
+    const ok = mani &&
+      isBefore(verTimes, defaultVer, time) &&
+      engineOk(mani, npmVersion, nodeVersion) &&
+      !mani.deprecated &&
+      !staged[defaultVer]
+    if (ok) {
       return mani
     }
   }
@@ -155,10 +161,10 @@ const pickManifest = (packument, wanted, opts) => {
       const [verb, manib] = b
       const notavoida = !shouldAvoid(vera, avoid)
       const notavoidb = !shouldAvoid(verb, avoid)
-      const notrestra = !restricted[a]
-      const notrestrb = !restricted[b]
-      const notstagea = !staged[a]
-      const notstageb = !staged[b]
+      const notrestra = !restricted[vera]
+      const notrestrb = !restricted[verb]
+      const notstagea = !staged[vera]
+      const notstageb = !staged[verb]
       const notdepra = !mania.deprecated
       const notdeprb = !manib.deprecated
       const enginea = engineOk(mania, npmVersion, nodeVersion)

--- a/test/index.js
+++ b/test/index.js
@@ -130,6 +130,9 @@ test('ETARGET if range does not match anything', t => {
 
 test('E403 if version is forbidden', t => {
   const metadata = {
+    'dist-tags': {
+      latest: '2.1.0', // do not default the latest if restricted
+    },
     policyRestrictions: {
       versions: {
         '2.1.0': { version: '2.1.0' },
@@ -141,6 +144,9 @@ test('E403 if version is forbidden', t => {
       '2.0.5': { version: '2.0.5' },
     },
   }
+  t.equal(pickManifest(metadata, '2').version, '2.0.5')
+  t.equal(pickManifest(metadata, '').version, '2.0.5')
+  t.equal(pickManifest(metadata, '1 || 2').version, '2.0.5')
   t.throws(() => {
     pickManifest(metadata, '2.1.0')
   }, { code: 'E403' }, 'got correct error on match failure')
@@ -423,6 +429,9 @@ test('accepts opts.before option to do date-based cutoffs', t => {
 
 test('prefers versions that satisfy the engines requirement', t => {
   const pack = {
+    'dist-tags': {
+      latest: '1.5.0', // do not default latest if engine mismatch
+    },
     versions: {
       '1.0.0': { version: '1.0.0', engines: { node: '>=4' } },
       '1.1.0': { version: '1.1.0', engines: { node: '>=6' } },
@@ -430,6 +439,8 @@ test('prefers versions that satisfy the engines requirement', t => {
       '1.3.0': { version: '1.3.0', engines: { node: '>=10' } },
       '1.4.0': { version: '1.4.0', engines: { node: '>=12' } },
       '1.5.0': { version: '1.5.0', engines: { node: '>=14' } },
+      // not tagged as latest, won't be chosen by default
+      '1.5.1': { version: '1.5.0', engines: { node: '>=14' } },
     },
   }
 


### PR DESCRIPTION
Previously, there were two problems.

First problem, even though we heuristically choose the version that best
suits the stated 'engines' restriction, we were skipping that check when
the 'defaultTag' (ie, 'latest', typically) version was a semver match.

Second problem, the heuristic was improperly being set for 'staged' and
'restricted' packages, resulting in failure to sort those versions
properly.

Only choose the defaultTag version if it both a semver match, _and_
passes the engines/staged/restricted heuristics, and apply those
heuristics properly in the sort that comes later, if the defaultTag
version is not used.

Related-to: https://github.com/npm/rfcs/pull/405

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
