### PR TITLE
Fixes npm/cli#2800: npm outdated fails to parse aliases

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,11 @@ const pickManifest = (packument, wanted, opts) => {
     packument.policyRestrictions.versions) || {}
 
   const time = before && verTimes ? +(new Date(before)) : Infinity
-  const spec = npa.resolve(name, wanted || defaultTag)
+  let spec = npa.resolve(name, wanted || defaultTag)
+  if (spec.type === 'alias') {
+    spec = spec.subSpec
+  }
+
   const type = spec.type
   const distTags = packument['dist-tags'] || {}
 


### PR DESCRIPTION
<!-- What / Why -->
Currently, with a `package.json` like this:

```json
{
  "name": "test-outdated-alias",
  "version": "1.0.0",
  "dependencies": {
    "foo": "npm:abbrev@^1.1.1"
  }
}
```

Running `npm outdated` produces an error because `npm-pick-manifest` throws an error when it sees the `alias` package type:

```
test-outdated-alias$ npm outdated --verbose
// snipped for brevity...
npm verb stack Error: Only tag, version, and range are supported
npm verb stack     at pickManifest (/usr/local/lib/node_modules/npm/node_modules/npm-pick-manifest/index.js:93:11)
npm verb stack     at module.exports (/usr/local/lib/node_modules/npm/node_modules/npm-pick-manifest/index.js:187:16)
npm verb stack     at Outdated.getOutdatedInfo (/usr/local/lib/node_modules/npm/lib/commands/outdated.js:229:22)
npm verb stack     at async Promise.all (index 5)
npm verb stack     at async Outdated.exec (/usr/local/lib/node_modules/npm/lib/commands/outdated.js:72:5)
npm verb stack     at async module.exports (/usr/local/lib/node_modules/npm/lib/cli.js:66:5)
```

So this PR changes `npm-pick-manifest` so that when it sees a package of type `alias`, it looks at its `subSpec` instead, basically ignoring the alias.


## References
This fixes https://github.com/npm/cli/issues/2800. I do not know if there is other code that relies on `npm-pick-manifest` failing on aliases, but I doubt it.