### PR TITLE
feat: decorate picked manifest with publish time

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -186,7 +186,7 @@ const pickManifest = (packument, wanted, opts) => {
 module.exports = (packument, wanted, opts = {}) => {
   const mani = pickManifest(packument, wanted, opts)
   // Decorate with publish time if available
-  const _time = mani && packument.time && packument.time[mani.version] || null
+  const _time = packument.time.?[mani?.version]]
   if (_time) {
     mani._time = _time
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -185,6 +185,11 @@ const pickManifest = (packument, wanted, opts) => {
 
 module.exports = (packument, wanted, opts = {}) => {
   const mani = pickManifest(packument, wanted, opts)
+  // Decorate with publish time if available
+  const _time = mani && packument.time && packument.time[mani.version] || null
+  if (_time) {
+    mani._time = _time
+  }
   const picked = mani && normalizeBin(mani)
   const policyRestrictions = packument.policyRestrictions
   const restricted = (policyRestrictions && policyRestrictions.versions) || {}

--- a/test/index.js
+++ b/test/index.js
@@ -606,3 +606,66 @@ test('normalize package bins', t => {
 
   t.end()
 })
+
+test('decorates created time', t => {
+  const name = 'foobar'
+  const metadata = {
+    name,
+    versions: {
+      '1.0.0': { name, version: '1.0.0' },
+      '1.0.1': { name, version: '1.0.1' },
+      '1.0.2': { name, version: '1.0.2' },
+      '2.0.0': { name, version: '2.0.0' },
+    },
+    time: {
+      '1.0.0': '2001-01-01T00:00:00.000Z',
+      '1.0.1': '2017-01-01T00:00:00.000Z',
+      '1.0.2': '2018-01-01T00:00:00.000Z',
+      '2.0.0': '2019-01-01T00:00:00.000Z',
+    },
+  }
+
+  const manifest = pickManifest(metadata, '^1.0.0')
+  t.strictSame(manifest, {
+    name,
+    version: '1.0.2',
+    _time: '2018-01-01T00:00:00.000Z',
+  }, 'decorated the package with time')
+
+  const metadataWithoutTime = {
+    name,
+    versions: {
+      '1.0.0': { name, version: '1.0.0' },
+      '1.0.1': { name, version: '1.0.1' },
+      '1.0.2': { name, version: '1.0.2' },
+      '2.0.0': { name, version: '2.0.0' },
+    },
+  }
+
+  const metadataNoTime = pickManifest(metadataWithoutTime, '^1.0.0')
+  t.strictSame(metadataNoTime, {
+    name,
+    version: '1.0.2',
+  }, 'ignores no time')
+
+  const metadataWithMissingTime = {
+    name,
+    versions: {
+      '1.0.0': { name, version: '1.0.0' },
+      '1.0.1': { name, version: '1.0.1' },
+      '1.0.2': { name, version: '1.0.2' },
+      '2.0.0': { name, version: '2.0.0' },
+    },
+    time: {
+      '2.0.0': '2018-01-01T00:00:00.000Z',
+    },
+  }
+
+  const metadataMissingTime = pickManifest(metadataWithMissingTime, '^1.0.0')
+  t.strictSame(metadataMissingTime, {
+    name,
+    version: '1.0.2',
+  }, 'ignores missing time for version')
+
+  t.end()
+})


### PR DESCRIPTION
Decorate the manifest with the publish time from the packument if this exists for the picked version.

This is used in pacote to pick a valid signing key when verifying registry signatures and attestations:
https://github.com/npm/pacote/pull/284
