### PR TITLE
fix: fallback for missing `packument.versions`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -210,7 +210,7 @@ module.exports = (packument, wanted, opts = {}) => {
     code,
     type: npa.resolve(packument.name, wanted).type,
     wanted,
-    versions: Object.keys(packument.versions),
+    versions: Object.keys(packument.versions ?? {}),
     name,
     distTags: packument['dist-tags'],
     defaultTag,

--- a/test/index.js
+++ b/test/index.js
@@ -606,3 +606,16 @@ test('normalize package bins', t => {
 
   t.end()
 })
+
+test('no matching version', t => {
+  const metadata = {
+    name: 'package',
+  }
+  const expectedVersion = '1.1.1'
+
+  t.throws(() => {
+    pickManifest(metadata, expectedVersion)
+  }, /No matching version found/)
+
+  t.end()
+})


### PR DESCRIPTION
`Object.keys` will throw if nullish value is provided. I faced the error when tried to install deps from our internal registry. This caused the following error:
```
10300 verbose stack TypeError: Cannot convert undefined or null to object
10300 verbose stack     at Function.keys (<anonymous>)
10300 verbose stack     at module.exports (~/node/18.17.0/lib/node_modules/npm/node_modules/npm-pick-manifest/lib/index.js:213:22)
10300 verbose stack     at RegistryFetcher.manifest (~/node/18.17.0/lib/node_modules/npm/node_modules/pacote/lib/registry.js:119:22)
10300 verbose stack     at async Promise.all (index 12)
10300 verbose stack     at async #buildDepStep (~/node/18.17.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:1034:5)
10300 verbose stack     at async Arborist.buildIdealTree (~/node/18.17.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:196:7)
10300 verbose stack     at async Promise.all (index 1)
10300 verbose stack     at async Arborist.reify (~/node/18.17.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:159:5)
10300 verbose stack     at async Install.exec (~/node/18.17.0/lib/node_modules/npm/lib/commands/install.js:147:5)
10300 verbose stack     at async module.exports (~/node/18.17.0/lib/node_modules/npm/lib/cli.js:89:5)
```

When I added the fallback, the error rendered fine and I was able to figure out what caused the problem:

Error example after the fix:
```
npm verb stack internal-package: No matching version found for internal-package@1.3.2.
npm verb stack     at module.exports (~/18.17.0/lib/node_modules/npm/node_modules/npm-pick-manifest/lib/index.js:209:23)
npm verb stack     at RegistryFetcher.manifest (~/18.17.0/lib/node_modules/npm/node_modules/pacote/lib/registry.js:119:22)
npm verb stack     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
npm verb stack     at async Promise.all (index 12)
npm verb stack     at async #buildDepStep (~/18.17.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:1034:5)
npm verb stack     at async Arborist.buildIdealTree (~/18.17.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/build-ideal-tree.js:196:7)
npm verb stack     at async Promise.all (index 1)
npm verb stack     at async Arborist.reify (~/18.17.0/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/reify.js:159:5)
npm verb stack     at async Install.exec (~/18.17.0/lib/node_modules/npm/lib/commands/install.js:147:5)
npm verb stack     at async module.exports (~/18.17.0/lib/node_modules/npm/lib/cli.js:89:5)
npm verb cwd /Users/user/internal-app
npm verb Darwin 21.6.0
npm verb node v18.17.0
npm verb npm  v9.6.7
npm ERR! code ETARGET
npm ERR! notarget No matching version found for internal-package@1.3.2.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
npm verb exit 1
```

Closes #79 