### PR TITLE
bump npm-install-checks, npm-normalize-package-bin

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -87,17 +87,11 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 16.14.0
-          - 16.x
           - 18.0.0
           - 18.x
           - 20.x
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 16.14.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 16.x
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 18.0.0
           - platform: { name: macOS, os: macos-13, shell: bash }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,17 +64,11 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 16.14.0
-          - 16.x
           - 18.0.0
           - 18.x
           - 20.x
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 16.14.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 16.x
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 18.0.0
           - platform: { name: macOS, os: macos-13, shell: bash }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "ISC",
   "dependencies": {
     "npm-install-checks": "^7.0.0",
-    "npm-normalize-package-bin": "^3.0.0",
+    "npm-normalize-package-bin": "^4.0.0",
     "npm-package-arg": "^11.0.0",
     "semver": "^7.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     ]
   },
   "engines": {
-    "node": "^16.14.0 || >=18.0.0"
+    "node": "^18.17.0 || ^20.5.0 || >=22.0.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "author": "GitHub Inc.",
   "license": "ISC",
   "dependencies": {
-    "npm-install-checks": "^6.0.0",
+    "npm-install-checks": "^7.0.0",
     "npm-normalize-package-bin": "^3.0.0",
     "npm-package-arg": "^11.0.0",
     "semver": "^7.3.5"


### PR DESCRIPTION
- Update `npm-install-checks` from `^6.0.0` to `^7.0.0`
- Update `npm-normalize-package-bin` from `^3.0.0` to `^4.0.0`
- **BREAKING:** drop support for legacy Node.js versions 16,17,19,21
  - due to deprecations in the above packages
  - ci: remove Node.js v16 from test matrix


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
